### PR TITLE
Add Github actions workflow file for docker build

### DIFF
--- a/.github/workflows/dockerhub-deploy.yaml
+++ b/.github/workflows/dockerhub-deploy.yaml
@@ -1,0 +1,42 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  REGISTRY_IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/99-nights-in-the-forest
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY_IMAGE }}:latest
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache,mode=max


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and publishing Docker images for the project. The workflow is triggered on pushes to the `main` branch and can also be run manually. It sets up the necessary environment, logs into Docker Hub using secrets, and builds and pushes multi-platform images with caching enabled.

**Continuous Integration & Deployment:**

* Added `.github/workflows/dockerhub-deploy.yaml` to automate Docker image build and publish on Docker Hub when changes are pushed to `main` or triggered manually.
* Configured multi-platform builds (`linux/amd64`, `linux/arm64`) and enabled build cache to speed up subsequent builds.
* Integrated Docker Hub authentication using repository secrets for secure publishing.