### PR TITLE
Added padding on pages' body

### DIFF
--- a/src/pages/generator.astro
+++ b/src/pages/generator.astro
@@ -72,7 +72,7 @@ const loadingMessages = [
   description="Claim Roblox items for survival in 99 Nights in the Forest. Choose an item, enter your username, and get a free code."
   showFooter={false}
 >
-  <main class="relative flex min-h-screen flex-col items-center overflow-hidden bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] px-4 py-0">
+  <main class="relative flex min-h-screen flex-col items-center overflow-hidden bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] px-4 py-0 pt-[130px] md:pt-[150px]">
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
       <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,#042739_0%,#01171f_55%,#000000_100%)]" />
       <div class="absolute left-1/2 top-1/2 h-[110%] w-[110%] -translate-x-1/2 -translate-y-1/2 overflow-hidden blur-[5px]">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import logo from "../assets/navLogo.png";
   description="Claim Roblox items for survival in 99 Nights in the Forest."
   showFooter={false}
 >
-  <main class="relative flex h-screen flex-col items-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 py-0">
+  <main class="relative flex h-screen flex-col items-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 py-0 lg:pt-[120px]">
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
       <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,#042739_0%,#01171f_55%,#000000_100%)]" />
       <div class="absolute left-1/2 top-1/2 h-[110%] w-[110%] -translate-x-1/2 -translate-y-1/2 overflow-hidden blur-[5px]">


### PR DESCRIPTION
This pull request makes small layout adjustments to the main content area on both the `generator.astro` and `index.astro` pages. The changes add top padding to ensure proper spacing, especially on larger screens.

Layout adjustments:

* Added `pt-[130px]` (and `md:pt-[150px]` for medium screens) to the main container in `generator.astro` to increase top padding.
* Added `lg:pt-[120px]` to the main container in `index.astro` to provide additional top padding on large screens.