### PR TITLE
Fix: Homepage background and padding

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import logo from "../assets/navLogo.png";
   description="Claim Roblox items for survival in 99 Nights in the Forest."
   showFooter={false}
 >
-  <main class="relative flex h-screen flex-col items-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 py-0 lg:pt-[120px]">
+  <main class="relative flex min-h-screen flex-col items-center justify-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 pt-[110px] pb-[80px] lg:pt-[120px]">
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
       <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,#042739_0%,#01171f_55%,#000000_100%)]" />
       <div class="absolute left-1/2 top-1/2 h-[110%] w-[110%] -translate-x-1/2 -translate-y-1/2 overflow-hidden blur-[5px]">


### PR DESCRIPTION
This pull request makes a minor adjustment to the layout of the main section in `src/pages/index.astro`. The change ensures that the main content is vertically centered and always fills at least the full height of the viewport, with appropriate padding at the top and bottom.

- Updated the `main` element's classes to use `min-h-screen`, add `justify-center`, and adjust padding for better vertical centering and spacing.