### PR TITLE
Fix padding on individual items page

### DIFF
--- a/src/pages/items/chainsaw.astro
+++ b/src/pages/items/chainsaw.astro
@@ -14,8 +14,9 @@ const breadcrumbs = [
 <Layout
   title="Free Chainsaw in 99 Nights in the Forest"
   description="Get a free chainsaw for 99 Nights in the Forest Roblox game. Learn how to obtain this powerful tool for tree cutting and defense. Instant delivery to your account."
+  showFooter={false}
 >
-  <main class="relative min-h-screen bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)]">
+  <main class="relative flex min-h-screen flex-col items-center justify-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 pt-[110px] pb-[80px] lg:pt-[120px]">
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
       <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,#042739_0%,#01171f_55%,#000000_100%)]" />
       <div class="absolute left-1/2 top-1/2 h-[110%] w-[110%] -translate-x-1/2 -translate-y-1/2 overflow-hidden blur-[5px]">

--- a/src/pages/items/diamonds.astro
+++ b/src/pages/items/diamonds.astro
@@ -14,8 +14,9 @@ const breadcrumbs = [
 <Layout
   title="Free Diamonds in 99 Nights in the Forest"
   description="Get free diamonds for 99 Nights in the Forest Roblox game. Choose from 5,000 or 10,000 diamonds packages. Instant delivery to your account. Updated daily!"
+  showFooter={false}
 >
-  <main class="relative min-h-screen bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)]">
+  <main class="relative flex min-h-screen flex-col items-center justify-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 pt-[110px] pb-[80px] lg:pt-[120px]">
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
       <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,#042739_0%,#01171f_55%,#000000_100%)]" />
       <div class="absolute left-1/2 top-1/2 h-[110%] w-[110%] -translate-x-1/2 -translate-y-1/2 overflow-hidden blur-[5px]">

--- a/src/pages/items/raygun.astro
+++ b/src/pages/items/raygun.astro
@@ -14,8 +14,9 @@ const breadcrumbs = [
 <Layout
   title="Free Ray Gun in 99 Nights in the Forest"
   description="Get a free ray gun for 99 Nights in the Forest Roblox game. This powerful alien tech weapon fires hit-scan projectiles with heavy damage. Instant delivery to your account."
+  showFooter={false}
 >
-  <main class="relative min-h-screen bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)]">
+  <main class="relative flex min-h-screen flex-col items-center justify-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 pt-[110px] pb-[80px] lg:pt-[120px]">
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
       <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,#042739_0%,#01171f_55%,#000000_100%)]" />
       <div class="absolute left-1/2 top-1/2 h-[110%] w-[110%] -translate-x-1/2 -translate-y-1/2 overflow-hidden blur-[5px]">


### PR DESCRIPTION
This pull request updates the layout and styling for the item pages (`chainsaw.astro`, `diamonds.astro`, and `raygun.astro`) to improve their appearance and user experience. The main changes include hiding the footer and enhancing the main content area's layout and responsiveness.

Layout and UI improvements:

* Added the `showFooter={false}` prop to the `Layout` component to hide the footer on all three item pages, creating a more focused user experience. [[1]](diffhunk://#diff-8f4c5242a92ee746f34fa5464eb7fc814b4e7db739b12ba7b38c14ff2572197bR17-R19) [[2]](diffhunk://#diff-c521c3c7832abb1cd48cb6b34a48cc38e4f04ad51d7694e41ec165358efd27a5R17-R19) [[3]](diffhunk://#diff-5184702d8ee0729ffa5e34787c9e4d08e3ea563509947729c36955e64acb6a98R17-R19)
* Updated the `<main>` element on each page to use a more flexible and centered layout with additional padding and responsive design, ensuring content is better aligned and visually appealing across different devices. [[1]](diffhunk://#diff-8f4c5242a92ee746f34fa5464eb7fc814b4e7db739b12ba7b38c14ff2572197bR17-R19) [[2]](diffhunk://#diff-c521c3c7832abb1cd48cb6b34a48cc38e4f04ad51d7694e41ec165358efd27a5R17-R19) [[3]](diffhunk://#diff-5184702d8ee0729ffa5e34787c9e4d08e3ea563509947729c36955e64acb6a98R17-R19)