### PR TITLE
Fix padding on guides page

### DIFF
--- a/src/pages/guides/beginner-tips.astro
+++ b/src/pages/guides/beginner-tips.astro
@@ -46,8 +46,9 @@ const tips = [
 <Layout
   title="Beginner Tips - 99 Nights in the Forest Guide"
   description="Essential beginner tips for 99 Nights in the Forest Roblox game. Learn how to survive your first nights, build a strong base, and gather resources effectively."
+  showFooter={false}
 >
-  <main class="relative min-h-screen bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)]">
+  <main class="relative flex min-h-screen flex-col items-center justify-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 pt-[110px] pb-[80px] lg:pt-[120px]">
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
       <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,#042739_0%,#01171f_55%,#000000_100%)]" />
       <div class="absolute left-1/2 top-1/2 h-[110%] w-[110%] -translate-x-1/2 -translate-y-1/2 overflow-hidden blur-[5px]">

--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -90,8 +90,9 @@ const getColorClasses = (color) => {
 <Layout
   title="Game Guides - 99 Nights in the Forest"
   description="Complete collection of guides for 99 Nights in the Forest Roblox game. Learn survival strategies, item usage, base building, and more from beginner to advanced tips."
+  showFooter={false}
 >
-  <main class="relative min-h-screen bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)]">
+  <main class="relative flex min-h-screen flex-col items-center justify-center overflow-auto bg-[linear-gradient(180deg,#000f15_0%,#000000_100%)] bg-fixed px-4 pt-[110px] pb-[80px] lg:pt-[120px]">
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
       <div class="absolute inset-0 bg-[radial-gradient(circle_at_center,#042739_0%,#01171f_55%,#000000_100%)]" />
       <div class="absolute left-1/2 top-1/2 h-[110%] w-[110%] -translate-x-1/2 -translate-y-1/2 overflow-hidden blur-[5px]">


### PR DESCRIPTION
This pull request updates the layout and styling for the beginner tips and guides pages to enhance their appearance and consistency. The main improvements involve updating the page structure to better center content, add padding, and hide the footer for a more focused reading experience.

Layout and UI enhancements:

* Updated the `<Layout>` component in both `beginner-tips.astro` and `index.astro` to set `showFooter={false}`, removing the footer from these guide pages for a cleaner look. [[1]](diffhunk://#diff-3ffebbdf0d7b8fb8b67da9fa71f2cf1c9e4ad33a4c38460bfaf4a14cff5ac820R49-R51) [[2]](diffhunk://#diff-06f412b36ec8737687945b8ab547fc3e44a746c9d15c48b02391aaeee72980f3R93-R95)
* Modified the `<main>` element in both files to use a flexbox layout, center the content, add responsive padding, and ensure the background is fixed. This improves readability and visual consistency across guide pages. [[1]](diffhunk://#diff-3ffebbdf0d7b8fb8b67da9fa71f2cf1c9e4ad33a4c38460bfaf4a14cff5ac820R49-R51) [[2]](diffhunk://#diff-06f412b36ec8737687945b8ab547fc3e44a746c9d15c48b02391aaeee72980f3R93-R95)