### PR TITLE
Integrate umami analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,12 +4,12 @@ import tailwindcss from "@tailwindcss/vite";
 import icon from "astro-icon";
 import robotsTxt from "astro-robots-txt";
 import { defineConfig } from "astro/config";
-
+import umami from "@yeskunall/astro-umami";
 import alpinejs from "@astrojs/alpinejs";
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://timbuilding.com",
+  site: "https://99nightsintheforestfree.com",
   vite: {
     plugins: [tailwindcss()],
   },
@@ -21,6 +21,11 @@ export default defineConfig({
       priority: 0.7,
     }),
     alpinejs(),
+    umami({
+      id:"78d86786-079b-49e7-bb2f-0007e2c5e12a",
+      endpointUrl:"https://analytics.growagardenfree.com",
+      hostUrl:"https://analytics.growagardenfree.com",
+    }),
     robotsTxt(),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astrojs/sitemap": "^3.4.0",
     "@tailwindcss/vite": "^4.1.7",
     "@types/alpinejs": "^3.13.11",
+    "@yeskunall/astro-umami": "0.0.7",
     "alpinejs": "^3.14.9",
     "astro": "^5.7.13",
     "astro-font": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@types/alpinejs':
         specifier: ^3.13.11
         version: 3.13.11
+      '@yeskunall/astro-umami':
+        specifier: 0.0.7
+        version: 0.0.7(astro@5.7.13(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.0)(typescript@5.8.3)(yaml@2.8.0))
       alpinejs:
         specifier: ^3.14.9
         version: 3.14.9
@@ -902,6 +905,11 @@ packages:
 
   '@vue/shared@3.1.5':
     resolution: {integrity: sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==}
+
+  '@yeskunall/astro-umami@0.0.7':
+    resolution: {integrity: sha512-8W/At28qKyPGepwvVumgJX0VZ0F9KK4M4zNDQfUZ3iBJpAKUTAkdIXM7i7I+PFsP7rXOo/AVgcDXDOv9L03QhQ==}
+    peerDependencies:
+      astro: ^3.0.0 || ^4.0.0 || ^5.0.0
 
   acorn@8.14.1:
     resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
@@ -3434,6 +3442,10 @@ snapshots:
       '@vue/shared': 3.1.5
 
   '@vue/shared@3.1.5': {}
+
+  '@yeskunall/astro-umami@0.0.7(astro@5.7.13(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.0)(typescript@5.8.3)(yaml@2.8.0))':
+    dependencies:
+      astro: 5.7.13(@types/node@22.15.21)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.0)(typescript@5.8.3)(yaml@2.8.0)
 
   acorn@8.14.1: {}
 


### PR DESCRIPTION
This pull request introduces Umami analytics tracking to the project and updates the site configuration. The main changes include adding the `@yeskunall/astro-umami` package, configuring it in `astro.config.mjs`, and updating the site URL.

**Analytics integration:**

* Added the `@yeskunall/astro-umami` package as a dependency in `package.json` and included it in the lockfile (`pnpm-lock.yaml`). [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R16) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23-R25) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR909-R913) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3446-R3449)
* Configured the Umami analytics plugin in `astro.config.mjs` with the appropriate `id`, `endpointUrl`, and `hostUrl` for tracking. [[1]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fL7-R12) [[2]](diffhunk://#diff-e0f0c5adbe0b9ca5d0b57caf5cea33a8d88899fd02a43df1e9862b185f8a1e5fR24-R28)

**Site configuration:**

* Updated the `site` URL in `astro.config.mjs` from `https://timbuilding.com` to `https://99nightsintheforestfree.com`.